### PR TITLE
Add DOI prettification and allow http:// protocol cleanup

### DIFF
--- a/_extensions/pretty-urls/pretty-urls.lua
+++ b/_extensions/pretty-urls/pretty-urls.lua
@@ -14,7 +14,8 @@ local function prettify_url (link)
     return nil
   end
 
-  link.content = link.target:gsub('^https%:%/%/', '')
+  link.content = link.target:gsub('^http(s)?%:%/%/', '')
+  link.content = link.content:gsub('^(d?x?%.?)doi%.org%/', 'DOI:') --prettify DOIs
   return link
 end
 


### PR DESCRIPTION
Please see #1 for the details. In this pull I also slightly modified the first gsub to allow either `https://` or `http://` protocols. I tested using pandoc:

```
▶︎ pandoc -L pretty-urls.lua -t html

Here is a http link: <http://test.org>.

Here is a https link: <https://test.org>

Here is a DOI: <http://dx.doi.org/10.1002/icd.2359>

DOI without the dx: <http://doi.org/10.1002/icd.2359>

<p>Here is a http link: <a href="http://test.org" class="uri">test.org</a>.</p>
<p>Here is a https link: <a href="https://test.org" class="uri">test.org</a></p>
<p>Here is a DOI: <a href="http://dx.doi.org/10.1002/icd.2359" class="uri">DOI:10.1002/icd.2359</a></p>
<p>Without the dx: <a href="http://doi.org/10.1002/icd.2359" class="uri">DOI:10.1002/icd.2359</a></p>
```